### PR TITLE
Imaging data registration: provide key-value metadata ingestion to omero

### DIFF
--- a/drop-boxes/register-omero-metadata/backendinterface.py
+++ b/drop-boxes/register-omero-metadata/backendinterface.py
@@ -355,15 +355,10 @@ def add_annotations_to_image(conn, image_id, key_value_data):
 from optparse import OptionParser
 
 ###OMERO server info
-#USERNAME = "usr"
-#PASSWORD = "pwd"
-#HOST = "host"
-#PORT = 4064
-USERNAME = "portal_usr_1"
-PASSWORD = "29tesT1ng_4ccez*_04/"
-HOST = "134.2.24.118"
+USERNAME = "usr"
+PASSWORD = "pwd"
+HOST = "host"
 PORT = 4064
-
 
 def get_args():
     parser = OptionParser()

--- a/drop-boxes/register-omero-metadata/image_registration_process.py
+++ b/drop-boxes/register-omero-metadata/image_registration_process.py
@@ -92,15 +92,15 @@ class ImageRegistrationProcess:
         pass
 
     #ToDo Check if Metadata file is provided as was suggested in test.tsv provided by LK
-    def extractMetadataFromTSV(self, tsvFilePath):
+    def extractMetadataFromTSV(self, tsv_file_path):
         tsvFileMap = {}
         try:
-            with open(tsvFilePath) as tsvfile:
+            with open(tsv_file_path) as tsvfile:
                 reader = csv.DictReader(tsvfile, delimiter='\t', strict=True)
                 for row in reader:
                     tsvFileMap.update(row)
         except IOError:
-            print "Error: No file found at provided filepath " + tsvFilePath
+            print "Error: No file found at provided filepath " + tsv_file_path
         except csv.Error as e:
             print 'Could not gather the Metadata from TSVfile %s, in line %d: %s' % (tsvfile, reader.line_num, e)
 
@@ -108,6 +108,29 @@ class ImageRegistrationProcess:
 
     def registerExperimentDataInOpenBIS(self):
         pass
+
+    def registerKeyValuePairs(self, image_id, property_map):
+        cmd_list = list(self._init_cmd_list)
+
+        #string format: key1::value1//key2::value2//key3::value3//...
+        key_value_str = ""
+        for key in property_map.keys(): 
+            key_value_str = key_value_str + str(key) + "::" + str(property_map[key]) + "//"
+        key_value_str = key_value_str[:len(key_value_str)-2] #remove last two chars
+        #print("irp str: " + key_value_str)
+
+        cmd_list.append( "python backendinterface.py -i " + str(image_id) + " -a " + key_value_str )
+
+        commands = ""
+        for cmd in cmd_list:
+            commands = commands + cmd + "\n"
+
+        process = Popen( "/bin/bash", shell=False, universal_newlines=True, stdin=PIPE, stdout=PIPE, stderr=PIPE )
+        out, err = process.communicate( commands )
+
+        #print(out)
+
+        return 0
 
 
 class SampleCodeError(Exception):

--- a/drop-boxes/register-omero-metadata/omero_54_env.yml
+++ b/drop-boxes/register-omero-metadata/omero_54_env.yml
@@ -1,0 +1,39 @@
+name: omero_env_0
+channels:
+  - bioconda
+  - sven1103
+  - hargup/label/pypi
+  - anaconda
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1=main
+  - bzip2=1.0.8=h7b6447c_0
+  - ca-certificates=2020.7.22=0
+  - certifi=2019.11.28=py27_0
+  - freetype=2.10.2=h5ab3b9f_0
+  - hashlib=20081119=py27_0
+  - jpeg=9b=habf39ab_1
+  - libedit=3.1.20191231=h14c3975_1
+  - libffi=3.3=he6710b0_2
+  - libgcc-ng=9.1.0=hdf63c60_0
+  - libpng=1.6.37=hbc83047_0
+  - libstdcxx-ng=9.1.0=hdf63c60_0
+  - libtiff=4.1.0=h2733197_1
+  - lz4-c=1.9.2=he6710b0_1
+  - ncurses=6.2=he6710b0_1
+  - olefile=0.46=py27_0
+  - omero-importer-cli=v1.0.0=0
+  - openjdk=8.0.152=h7b6447c_3
+  - openssl=1.0.2u=h7b6447c_0
+  - pillow=6.2.1=py27h34e0f95_0
+  - pip=19.3.1=py27_0
+  - python=2.7.18=h15b4118_1
+  - readline=8.0=h7b6447c_0
+  - setuptools=44.0.0=py27_0
+  - sqlite=3.33.0=h62c20be_0
+  - tk=8.6.10=hbc83047_0
+  - wheel=0.33.6=py27_0
+  - xz=5.2.5=h7b6447c_0
+  - zeroc-ice=3.6.3=py27hd0a1c67_1
+  - zlib=1.2.11=h7b6447c_3
+  - zstd=1.4.4=h0b5b093_3


### PR DESCRIPTION
The ETL script and related modules can now properly register metadata properties in the OMERO server as key-value pairs. The ETL script now reads the TSV and creates a property map for each file, it then uses the backend module to register the property pairs. I verified that the metadata properties are properly registered in the OMERO server.

this is a sample of the ETL output for test dataset 3:

New incoming image file for OMERO registration:	/home/qeana10/dss/store/1/pre-staging/2021-02-25_12-46-46-408_register-omero-metadata_QIMGT654A2/QIMGT654A2/sub_tomo_1.mrc
Created OMERO image identifiers:	['11035']
Metadata properties:	
KEY : VALUE
--> SAMPLE_BARCODE : QIMGT649A1
--> IMAGING_MODALITY : Cryo-ET
--> IMAGE_BINNING : 2
--> IMAGED_TISSUE : cell
--> CAMERA_ACQUISITION_TIME : 0.15
--> INSTRUMENT_MANUFACTURER : FEI
New incoming image file for OMERO registration:	/home/qeana10/dss/store/1/pre-staging/2021-02-25_12-46-46-408_register-omero-metadata_QIMGT654A2/QIMGT654A2/rubisco_avg.mrc
Created OMERO image identifiers:	['11036']
Metadata properties:	
KEY : VALUE
--> SAMPLE_BARCODE : QIMGT649A1
--> IMAGING_MODALITY : Cryo-ET
--> IMAGE_BINNING : 2
--> IMAGED_TISSUE : cell
--> CAMERA_ACQUISITION_TIME : 0.15
--> INSTRUMENT_MANUFACTURER : FEI
New incoming image file for OMERO registration:	/home/qeana10/dss/store/1/pre-staging/2021-02-25_12-46-46-408_register-omero-metadata_QIMGT654A2/QIMGT654A2/Image7246.tif
Created OMERO image identifiers:	['11037']
Metadata properties:	
KEY : VALUE
--> SAMPLE_BARCODE : QIMGT649A1
--> IMAGING_MODALITY : TEM
--> IMAGE_BINNING : 2
--> IMAGED_TISSUE : leaf
--> CAMERA_ACQUISITION_TIME : 0.15
--> INSTRUMENT_MANUFACTURER : Zeiss
New incoming image file for OMERO registration:	/home/qeana10/dss/store/1/pre-staging/2021-02-25_12-46-46-408_register-omero-metadata_QIMGT654A2/QIMGT654A2/Est-B1a.lif
Created OMERO image identifiers:	['11038', '11039', '11040', '11041']
Metadata properties:	
KEY : VALUE
--> SAMPLE_BARCODE : QIMGT649A1
--> IMAGING_MODALITY : confocal_microscopy
--> IMAGE_BINNING : 2
--> IMAGED_TISSUE : root
--> CAMERA_ACQUISITION_TIME : 0.15
--> INSTRUMENT_MANUFACTURER : Zeiss
New incoming image file for OMERO registration:	/home/qeana10/dss/store/1/pre-staging/2021-02-25_12-46-46-408_register-omero-metadata_QIMGT654A2/QIMGT654A2/Image_1.czi
Created OMERO image identifiers:	['11042']
Metadata properties:	
KEY : VALUE
--> SAMPLE_BARCODE : QIMGT649A1
--> IMAGING_MODALITY : confocal_microscopy
--> IMAGE_BINNING : 2
--> IMAGED_TISSUE : leaf
--> CAMERA_ACQUISITION_TIME : 0.15
--> INSTRUMENT_MANUFACTURER : Zeiss
New incoming image file for OMERO registration:	/home/qeana10/dss/store/1/pre-staging/2021-02-25_12-46-46-408_register-omero-metadata_QIMGT654A2/QIMGT654A2/Image_2.czi
Created OMERO image identifiers:	['11043']
Metadata properties:	
KEY : VALUE
--> SAMPLE_BARCODE : QIMGT649A1
--> IMAGING_MODALITY : confocal_microscopy
--> IMAGE_BINNING : 2
--> IMAGED_TISSUE : leaf
--> CAMERA_ACQUISITION_TIME : 0.15
--> INSTRUMENT_MANUFACTURER : Zeiss

![Screenshot 2021-02-25 at 13 05 39](https://user-images.githubusercontent.com/38211686/109151245-338c3f00-776a-11eb-9ee8-889c110ed18d.png)

