### PR TITLE
fix wiff dropbox issue

### DIFF
--- a/drop-boxes/register-wiff-dropbox/register-wiff-data-dropbox.py
+++ b/drop-boxes/register-wiff-dropbox/register-wiff-data-dropbox.py
@@ -75,7 +75,7 @@ def register_wiff_pairs(transaction, wiff_pairs, qbic_id):
     """
     space, project = space_and_project(transaction, qbic_id)
     experiments = transaction.getSearchService().listExperiments('/{}/{}'.format(space, project))
-    exp_ids = [int(re.search(r'\d.*', oid.getExperimentIdentifier()).group(0)) for oid in experiments if re.search(r'\d', oid.getExperimentIdentifier())]
+    exp_ids = [int(re.search(r'Q\w{4}E(\d+)', oid.getExperimentIdentifier()).group(0)) for oid in experiments if re.search(r'Q\w{4}E(\d+)', oid.getExperimentIdentifier())]
     exp_ids.sort()
     last_exp_id = exp_ids[-1]
 


### PR DESCRIPTION
use a regex that enables to find the running experiment number even for space and project names that contain digits. Fixes #97 