### PR TITLE
Hotfix/dm 456 fix vcf registration

### DIFF
--- a/drop-boxes/register-imgag-dropbox/register-imgag.py
+++ b/drop-boxes/register-imgag-dropbox/register-imgag.py
@@ -260,12 +260,6 @@ def find_and_register_vcf(transaction, jsonContent, varcode, parentCodeSet):#var
     newVCSample.setParentSampleIdentifiers(parentIdentifiers)
     newVCSample.setExperiment(newVCExp)
 
-    #additionalInfo = ""
-    #secName = ""
-    #for i, parentBarcode in enumerate(qbicBarcodes):
-#		additionalInfo += '%s %s Tumor: %s \n' % (qbicBarcodes[i], geneticIDS[i], sampleSource[i])
-#		secName += '%s ' % (geneticIDS[i])
-
     secName = secName.strip()
     #additionalInfo = '%s %s Tumor: %s \n %s %s Tumor: %s' % (qbicBarcodes[0], geneticIDS[0], sampleSource[0], qbicBarcodes[1], geneticIDS[1], sampleSource[1])
 

--- a/drop-boxes/register-imgag-dropbox/register-imgag.py
+++ b/drop-boxes/register-imgag-dropbox/register-imgag.py
@@ -42,7 +42,7 @@ SAMPLE_TRACKER = SampleTracker.createQBiCSampleTracker(SERVICE_REGISTRY_URL, SER
 
 # Data import and registration
 # *Q[Project Code]^4[Sample No.]^3[Sample Type][Checksum]*.*
-pattern = re.compile('Q\w{4}[0-9]{3}[a-zA-Z]\w')
+pattern = re.compile('Q\w{4}[0-9]{3}[a-xA-X]\w')
 typesDict = {'dna_seq': 'DNA', 'rna_seq': 'RNA', 'dna_seq_somatic': 'DNA'}
 
 def parse_metadata_file(filePath):

--- a/drop-boxes/register-imgag-dropbox/register-imgag.py
+++ b/drop-boxes/register-imgag-dropbox/register-imgag.py
@@ -604,20 +604,6 @@ def process(transaction):
                     tsvs.append(rawFile)
                 else:
                     raise Exception(rawFile + " is of an unsupported format")
-
-            #if rawFiles[0].endswith("vcf") or rawFiles[0].endswith("vcf.gz"):
-            #	datasetSample = find_and_register_vcf(transaction, jsonContent)
-            #
-            #	dataSet = transaction.createNewDataSet("Q_NGS_VARIANT_CALLING_DATA")
-            #	dataSet.setSample(datasetSample)
-
-            #elif rawFiles[0].endswith("fastq") or rawFiles[0].endswith("fastq.gz"):
-            #	datasetSample = find_and_register_ngs(transaction, jsonContent)
-
-            #	dataSet = transaction.createNewDataSet("Q_NGS_RAW_DATA")
-                #	dataSet.setSample(datasetSample)
-
-                #os.remove(os.path.realpath(os.path.join(os.path.join(incomingPath,name),f)))
         else:
             pass
     folder = os.path.join(incomingPath, name)

--- a/drop-boxes/register-imgag-dropbox/register-imgag.py
+++ b/drop-boxes/register-imgag-dropbox/register-imgag.py
@@ -87,6 +87,7 @@ def get_space_from_project(transaction, project):
     return space
 
 def find_and_register_vcf(transaction, jsonContent, varcode, parentCodeSet):#varcode example: GS130715_03-GS130717_03 (verified in startup.log)
+    # if no fastq files are in the dataset, the parentCodeSet is empty, here
     qbicBarcodes = []
     geneticIDS = []
     sampleSource = []
@@ -216,6 +217,12 @@ def find_and_register_vcf(transaction, jsonContent, varcode, parentCodeSet):#var
                                 print(testParentID)
                                 print(testParentIdentifiers)
 
+    if len(testParentIdentifiers) != len(geneticIDS):
+        print("Referenced sample identifiers do not fit the amount of known samples:")
+        print("Genetics Identifiers: " + geneticIDS)
+        print("Related sample ids in openBIS: " + testParentIdentifiers)
+        raise AssertionError("Referenced samples do not match metadata found in openBIS. Sequencing data might not be registered or indexed yet. Rerunning registration later might solve this problem.")
+
     numberOfExperiments += 1
     existingExperimentIDs = []
     existingExperiments = search_service.listExperiments("/" + space + "/" + project)
@@ -230,16 +237,11 @@ def find_and_register_vcf(transaction, jsonContent, varcode, parentCodeSet):#var
         newExpID = '/' + space + '/' + project + '/' + project + 'E' +str(numberOfExperiments)
         
     newVCExp = transaction.createNewExperiment(newExpID, "Q_NGS_VARIANT_CALLING")
-    identString = varcode # not used atm
-    #for genID in geneticIDS:
-    #	identString += genID.split('_')[-1]
 
-    identString2 = ''
-    print(testParentIdentifiers)
-    identString2 = '_'.join([tpi.split('/')[-1] for tpi in testParentIdentifiers])
+    print('test sample parent identifiers: ' + testParentIdentifiers)
+    identString = '_'.join([tpi.split('/')[-1] for tpi in testParentIdentifiers])
 
-    print('identstring ' + identString2)
-
+    print('id string for vcf sample: ' + identString)
 
     existingSampleIDs = []
         


### PR DESCRIPTION
* if referenced identifiers for vcf registration do not match the openBIS metadata, raise exception and stop registration instead of using incomplete sample codes and parent sample connections
* remove unused code
* remove 'Y' and 'Z' from valid barcode characters (input device localization issues non-specific to this script)
* add better logging