### PR TITLE
better check for existing samples

### DIFF
--- a/drop-boxes/register-hlatyping-dropbox/register-hlatyping.py
+++ b/drop-boxes/register-hlatyping-dropbox/register-hlatyping.py
@@ -67,11 +67,11 @@ def process(transaction):
         print "The identifier "+identifier+" did not match the pattern Q[A-Z]{4}\d{3}\w{2} or checksum"
         
     search_service = transaction.getSearchService()
-    sc = SearchCriteria()
-    pc = SearchCriteria()
-    pc.addMatchClause(SearchCriteria.MatchClause.createAttributeMatch(SearchCriteria.MatchClauseAttribute.PROJECT, project));
-    sc.addSubCriteria(SearchSubCriteria.createExperimentCriteria(pc))
-    foundSamples = search_service.searchForSamples(sc)
+    searchCriteria = SearchCriteria()
+    projectCriteria = SearchCriteria()
+    projectCriteria.addMatchClause(SearchCriteria.MatchClause.createAttributeMatch(SearchCriteria.MatchClauseAttribute.PROJECT, project));
+    searchCriteria.addSubCriteria(SearchSubCriteria.createExperimentCriteria(projectCriteria))
+    foundSamples = search_service.searchForSamples(searchCriteria)
     if len(foundSamples) > 0:
         space = foundSamples[0].getSpace()
         parentSampleIdentifier = "/"+space+"/"+parentCode

--- a/drop-boxes/register-hlatyping-dropbox/register-hlatyping.py
+++ b/drop-boxes/register-hlatyping-dropbox/register-hlatyping.py
@@ -95,9 +95,6 @@ def process(transaction):
         numberOfExperiments += 1 
         newExpID = '/' + space + '/' + project + '/' + project + 'E' +str(numberOfExperiments)
 
-    newHLATypingExperiment = transaction.createNewExperiment(newExpID, "Q_NGS_HLATYPING")
-    newHLATypingExperiment.setPropertyValue('Q_CURRENT_STATUS', 'FINISHED')
-
     if os.path.isdir(incomingPath):
         for root, subFolders, files in os.walk(incomingPath):
             if subFolders:
@@ -118,12 +115,13 @@ def process(transaction):
         mhcClass = "MHC_CLASS_I"
         mhcSuffix = "1"
     # does HLA sample of this class already exist?
-    hlaCode = 'HLA' + mhcSuffix + parentCode
-    hlaSampleID = "/"+space+"/"+hlaCode
-    HLATypingSample = transaction.getSampleForUpdate(hlaSampleID)
-    if not hlaSample:
-        HLATypingSample = transaction.createNewSample('/' + space + '/' + hlaCode, "Q_NGS_HLATYPING")
+    HLASampleID = "/"+space+"/"+'HLA' + mhcSuffix + parentCode
+    HLATypingSample = transaction.getSampleForUpdate(HLASampleID)
+    if not HLATypingSample:
+        HLATypingSample = transaction.createNewSample(HLASampleID, "Q_NGS_HLATYPING")
         HLATypingSample.setParentSampleIdentifiers([parentSampleIdentifier])
+        newHLATypingExperiment = transaction.createNewExperiment(newExpID, "Q_NGS_HLATYPING")
+        newHLATypingExperiment.setPropertyValue('Q_CURRENT_STATUS', 'FINISHED')
         HLATypingSample.setExperiment(newHLATypingExperiment)
         HLATypingSample.setPropertyValue("Q_HLA_CLASS", mhcClass)
 


### PR DESCRIPTION
make hla-typing result registration more stable by:

* getting parent sample identifier from space and barcode instead of trying to search the specific sample
* try to fetch existing hla typing sample by using its identifier
* only create new sample if that doesn't work
* only creating new experiment if needed