### PR TITLE
add error handling via email for attachment upload

### DIFF
--- a/drop-boxes/register-attachments-dropbox/register-attachment-dropbox.py
+++ b/drop-boxes/register-attachments-dropbox/register-attachment-dropbox.py
@@ -46,6 +46,10 @@ class CouldNotCreateException(Exception):
 	"Thrown when necessary experiment or sample could not be created."
 	pass
 
+def getInfoExperimentIdentifier(space, project):
+	experimentID = '/' + space + '/' + project + '/'+ project+'_INFO'
+	return experimentID
+
 def process(transaction):
 	error = None
 	originalError = None
@@ -123,7 +127,7 @@ def process(transaction):
 		if not sa:
 			# create necessary objects if sample really doesn't exist
 			try:
-				experimentID = '/' + space + '/' + project + '/'+ project+'_INFO'
+				experimentID = getInfoExperimentIdentifier(space, project)
 				exp = transaction.createNewExperiment(experimentID, "Q_PROJECT_DETAILS")
 			except Exception as exception:
 				originalError = exception

--- a/drop-boxes/register-attachments-dropbox/register-attachment-dropbox.py
+++ b/drop-boxes/register-attachments-dropbox/register-attachment-dropbox.py
@@ -38,7 +38,7 @@ class MetadataFormattingException(Exception):
 	"Thrown when metadata file cannot be successfully parsed."
 	pass
 
-class MissingProjectContextException(Exception):
+class NoSamplesFoundForProjectException(Exception):
 	"Thrown when sample cannot be found in openBIS."
 	pass
 
@@ -116,7 +116,7 @@ def process(transaction):
 			sample = foundSamples[0]
 		except IndexError as exception:
 			originalError = exception
-			error = MissingProjectContextException("No sample could be found for this project.")
+			error = NoSamplesFoundForProjectException("No sample could be found for this project.")
 		sampleID = sample.getSampleIdentifier()
 		sa = transaction.getSampleForUpdate(sampleID)
 		space = sa.getSpace()

--- a/drop-boxes/register-attachments-dropbox/register-attachment-dropbox.py
+++ b/drop-boxes/register-attachments-dropbox/register-attachment-dropbox.py
@@ -25,7 +25,9 @@ from ch.systemsx.cisd.openbis.generic.shared.api.v1.dto import SearchSubCriteria
 #ppattern = re.compile('Q\w{4}000')
 #epattern = re.compile('Q\w{4}E[1-9][0-9]*')
 
+# contains properties used to send emails, e.g. the mail server and the "from" address to use
 import email_helper_qbic as email_helper
+# provides functionality used to send emails, e.g. about registration errors
 import etl_mailer
 
 class MetadataFormattingException(Exception):
@@ -68,7 +70,6 @@ def process(transaction):
 					except IndexError as exception:
 						originalError = exception
 						error = MetadataFormattingException("Metadata file not correctly formatted. Check for additional line breaks.")
-						continue
 				metadata.close()
 				try:
 					user = fileInfo["user"]


### PR DESCRIPTION
- uses provided user name and uni host to send error mails
- no LDAP support, yet
- mails useful information on 3 known error cases to the user
- mails original error message in other error cases
- if email cannot be sent, logs this
- throws original error message after attempting to send email